### PR TITLE
[Fixbug]: Only first item in IGNORE_VIEW_NAMES is processed

### DIFF
--- a/login_required/middleware.py
+++ b/login_required/middleware.py
@@ -3,8 +3,8 @@ import re
 from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
+from django.urls import resolve
 from django.utils.deprecation import MiddlewareMixin
-from django.urls import resolve, Resolver404
 
 IGNORE_PATHS = [re.compile(settings.LOGIN_URL)]
 IGNORE_PATHS += [
@@ -27,20 +27,14 @@ class LoginRequiredMiddleware(MiddlewareMixin):
         )
 
         path = request.path
-        if not request.user.is_authenticated:
+        if request.user.is_authenticated:
+            return
 
-            if request.is_ajax():
-                raise PermissionDenied()
+        if request.is_ajax():
+            raise PermissionDenied()
 
-            for name in IGNORE_VIEW_NAMES:
-                try:
-                    resolver = resolve(path)
-                    if resolver.view_name == name:
-                        return None
-                    else:
-                        return redirect_to_login(path)
-                except Resolver404:
-                    return redirect_to_login(path)
+        resolver = resolve(path)
+        views = ((name == resolver.view_name) for name in IGNORE_VIEW_NAMES)
 
-            if not any(url.match(path) for url in IGNORE_PATHS):
-                return redirect_to_login(path)
+        if not any(views) and not any(url.match(path) for url in IGNORE_PATHS):
+            return redirect_to_login(path)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -40,9 +40,9 @@ class LoginRequiredMiddlewareTestCase(TestCase):
         response = self.client.get('/foo/')
         self.assertEqual(response.status_code, 200)
 
-    @mock.patch('login_required.middleware.IGNORE_VIEW_NAMES', ['foo'])
+    @mock.patch('login_required.middleware.IGNORE_VIEW_NAMES', ['foo', 'bar'])
     def test_ignore_url_names_config(self):
-        response = self.client.get('/foo/')
+        response = self.client.get('/bar/')
         self.assertEqual(response.status_code, 200)
 
     @mock.patch('login_required.middleware.IGNORE_VIEW_NAMES', ['app:foo'])
@@ -59,6 +59,10 @@ class LoginRequiredMiddlewareTestCase(TestCase):
     def test_ignore_url_names_invalid_path_call_config(self):
         response = self.client.get('/bar/')
         self.assertEqual(response.status_code, 302)
+
+    def test_raise_404(self):
+        response = self.client.get('/nonexistent-url/')
+        self.assertEqual(response.status_code, 404)
 
     def test_ajax_request(self):
         response = self.client.get('/foo/',

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -7,6 +7,7 @@ urlpatterns_with_namespace = [
 ]
 
 urlpatterns = [
+    url(r'^bar/$', lambda request: HttpResponse('bar'), name='bar'),
     url(r'^foo/$', lambda request: HttpResponse('foo'), name='foo'),
     url(r'^admin/', admin.site.urls),
     url('', include((urlpatterns_with_namespace, 'app')))


### PR DESCRIPTION
Resolve: #5 

- Bug fixed
- Removed Resolver404 irrelevant validation
- More tests