### PR TITLE
Fix test to match name definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ regex paths (`settings.LOGIN_URL` always included).
 
     ```python
     LOGIN_REQUIRED_IGNORE_PATHS = [
-        r'/accounts/logout/$'
+        r'/accounts/logout/$',
         r'/accounts/signup/$',
         r'/admin/$',
         r'/about/$'

--- a/login_required/middleware.py
+++ b/login_required/middleware.py
@@ -10,9 +10,7 @@ IGNORE_PATHS = [
     re.compile(url) for url in getattr(settings, "LOGIN_REQUIRED_IGNORE_PATHS", [])
 ]
 
-IGNORE_VIEW_NAMES = [
-    name for name in getattr(settings, "LOGIN_REQUIRED_IGNORE_VIEW_NAMES", [])
-]
+IGNORE_VIEW_NAMES = list(getattr(settings, "LOGIN_REQUIRED_IGNORE_VIEW_NAMES", []))
 
 
 class LoginRequiredMiddleware(AuthenticationMiddleware):

--- a/login_required/middleware.py
+++ b/login_required/middleware.py
@@ -14,7 +14,8 @@ IGNORE_VIEW_NAMES = list(getattr(settings, "LOGIN_REQUIRED_IGNORE_VIEW_NAMES", [
 
 
 class LoginRequiredMiddleware(AuthenticationMiddleware):
-    def _login_required(self, request):
+    @staticmethod
+    def _login_required(request):
         if request.user.is_authenticated:
             return None
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -44,9 +44,10 @@ class TestMiddleware:
         assert response.status_code == 200
 
     def test_redirect_404(self, client):
+        client.force_login(user_obj)
         response = client.get("/nonexistent-url/")
 
-        assert response.status_code == 302
+        assert response.status_code == 404
 
 
 class TestIgnorePaths:


### PR DESCRIPTION
Hi,

While I was looking at the code, I found a small issue with one of your test. This is saying that you expect a `404` but you check for a `302`.

I've proposed a change that should match the expected behavior.