### PR TITLE
Support django-rest-framework token-based login

### DIFF
--- a/login_required/middleware.py
+++ b/login_required/middleware.py
@@ -46,11 +46,14 @@ class LoginRequiredMiddleware(AuthenticationMiddleware):
 
         return redirect_to_login(path, redirect_field_name=REDIRECT_FIELD_NAME)
 
-    def process_request(self, request):
+    def process_response(self, request, response):
         """
-        Use process_request instead of defining __call__ directly;
+        Use process_response instead of defining __call__ directly;
         Django's middleware layer will process_request in a coroutine in __acall__ if it detects an async context.
         Otherwise, it will use __call__.
         https://github.com/django/django/blob/acde91745656a852a15db7611c08cabf93bb735b/django/utils/deprecation.py#L88-L148
+
+        Using process_response instead of process_request allows login
+        via django-rest-framework token (if installed) before checking.
         """
-        return self._login_required(request)
+        return self._login_required(request) or response

--- a/login_required/middleware.py
+++ b/login_required/middleware.py
@@ -49,7 +49,8 @@ class LoginRequiredMiddleware(AuthenticationMiddleware):
     def process_response(self, request, response):
         """
         Use process_response instead of defining __call__ directly;
-        Django's middleware layer will process_request in a coroutine in __acall__ if it detects an async context.
+        Django's middleware layer will process_request and process_response
+        in a coroutine in __acall__ if it detects an async context.
         Otherwise, it will use __call__.
         https://github.com/django/django/blob/acde91745656a852a15db7611c08cabf93bb735b/django/utils/deprecation.py#L88-L148
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -30,7 +30,9 @@ class TestMiddleware:
         request.user = user
         del request.user
 
-        with pytest.raises((AttributeError, ImproperlyConfigured)):
+        with pytest.raises(
+            (AttributeError, ImproperlyConfigured, AssertionError),
+        ):
             middleware.process_request(request)
 
     def test_redirect_to_login(self, client):


### PR DESCRIPTION
Fix #80 

Currently, when `LoginRequiredMiddleware` is enabled, Django Rest Framework can no longer use tokens to authenticate, and will always return a `302` status without a chance to login. For the project I'm integrating into, I need both login and tokens to be available.

This is due to the token-based login occurring after all middleware has gone through the `process_request()` phase, but before the `process_response()` phase. `LoginRequiredMiddleware` expects authentication to have already happened thanks to `AuthenticationMiddleware`, and thus DRF never gets a chance to look at the token before we get redirected.

There's nothing as far as I can tell forbidding `_login_required()` from running on the way back info `process_response()`.

After the changes, the expected exception raised during test `test_user_required` changes to an `AssertionError` but otherwise all tests pass. Also if DRF cannot login with the provided token, the redirect will still occur as intended by `LoginRequiredMiddleware`.

Thanks